### PR TITLE
Install zlib for pillow

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -7,7 +7,7 @@ if [ -e cuda_deps/setup.py ]; then
   python cuda_deps/setup.py -q install
 fi
 
-apt-get install -y libjpeg-dev
+apt-get install -y libjpeg-dev zlib1g-dev
 pip install pillow
 
 cd examples


### PR DESCRIPTION
To install pillow, we need to install zlib. I don't know why the test has worked before.