### PR TITLE
Fix installation method of cudnn

### DIFF
--- a/make_docker.py
+++ b/make_docker.py
@@ -156,15 +156,23 @@ codes['cuda75'] = cuda75_base.format(
 
 # cudnn
 
-cudnn_base = '''
+codes['cudnn2'] = '''
 WORKDIR /opt/cudnn
-ENV CUDNN {cudnn}
-ADD $CUDNN.tgz /opt/cudnn/
+ENV CUDNN cudnn-6.5-linux-x64-v2
+COPY $CUDNN.tgz /opt/cudnn/
+RUN tar zxf $CUDNN.tgz
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/cudnn/$CUDNN
+ENV CPATH $CPATH:/opt/cudnn/$CUDNN
 '''
 
-codes['cudnn2'] = cudnn_base.format(cudnn='cudnn-6.5-linux-x64-v2')
-codes['cudnn3'] = cudnn_base.format(cudnn='cudnn-7.0-linux-x64-v3.0-prod')
+codes['cudnn3'] = '''
+WORKDIR /opt/cudnn
+ENV CUDNN cudnn-7.0-linux-x64-v3.0-prod
+COPY $CUDNN.tgz /opt/cudnn/
+RUN tar zxf $CUDNN.tgz
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/cudnn/cuda/lib64
+ENV CPATH $CPATH:/opt/cudnn/cuda/include
+'''
 
 codes['none'] = ''
 


### PR DESCRIPTION
Directory structures are different between cudnn2 and cudnn3.

cudnn2
```
cudnn-6.5-linux-x64-v2
 + cudnn.h
 + libcudnn.so
```

cudnn3
```
cuda
 + include
 |  + cudnn.h
 + lib64
    + libcudnn.so
```

