### PR TITLE
Upgrade pip

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+pip install -U pip
+
 cd chainer
 python setup.py -q develop install
 

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+pip install -U pip
+
 cd chainer
 python setup.py develop
 python setup.py install

--- a/test_example.sh
+++ b/test_example.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+pip install -U pip
+
 cd chainer
 rm -rf dist
 python setup.py -q sdist

--- a/test_prev_example.sh
+++ b/test_prev_example.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+pip install -U pip
+
 PREV_VER=1.3.2
 CHAINER_DIR=chainer-${PREV_VER}
 


### PR DESCRIPTION
We cannot setup chainer with old pip wit py3. 