### PR TITLE
Test install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ $ docker run --env COVERALLS_REPO_TOKEN=XXX..X -v ${pwd}:/work -w /work \
   --device /dev/nvidia-uvm:/dev/nvidia-uvm ./test.sh
 ```
 
+## Test scripts
+
+- `test.sh`: build and run all tests.
+- `test_cpu.sh`: build and run only tests for CPUs.
+- `test_example.sh`: build and run all examples.
+- `test_example.sh`: build and run all examples of previous version.
+- `test_doc.sh`: build the document and run document test.
+- `test_install.sh`: make source distribution package and install it with given environment.
+
+
 ## In Jenkins
 
 Make a multi-configuration project.

--- a/build_sdist.sh
+++ b/build_sdist.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+cd chainer
+python setup.py -q develop sdist

--- a/test_install.sh
+++ b/test_install.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+
+pip install $DEPENDENCY
+
+pip install -vvvv chainer/dist/*.tar.gz

--- a/test_install.sh
+++ b/test_install.sh
@@ -2,4 +2,4 @@
 
 pip install $DEPENDENCY
 
-pip install -vvvv chainer/dist/*.tar.gz
+timeout 20m pip install -vvvv chainer/dist/*.tar.gz

--- a/test_install.sh
+++ b/test_install.sh
@@ -3,3 +3,7 @@
 pip install $DEPENDENCY
 
 timeout 20m pip install -vvvv chainer/dist/*.tar.gz
+
+# check if cupy is installed
+python -c 'import cupy'
+


### PR DESCRIPTION
I made two script to test installation.
One script makes source distribution package. The other tries to install the package.
We need to test if a system can install source distribution package in a **clean** environment. We need to split these two steps because `setup.py` installs dependent packages when it makes a source distribution.