### PR TITLE
Fix install method of sdist

### DIFF
--- a/build_sdist.sh
+++ b/build_sdist.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -ex
 
 cd chainer
-python setup.py -q develop sdist
+pip install cython
+python setup.py -q sdist


### PR DESCRIPTION
To make source dist file, we only need to install cython.