### PR TITLE
Ignore requires option when is is not specified

### DIFF
--- a/make_docker.py
+++ b/make_docker.py
@@ -214,6 +214,7 @@ with open(args.dockerfile, 'w') as f:
     f.write(codes[args.cuda])
     f.write(codes[args.cudnn])
 
-    f.write('\n')
-    for r in args.requires:
-        f.write('RUN pip install %s\n' % r)
+    if args.requires:
+        f.write('\n')
+        for r in args.requires:
+            f.write('RUN pip install %s\n' % r)


### PR DESCRIPTION
When `--requires` option is not specified, `args.requires` is `None`. So, we need to ignore it in such case.