### PR TITLE
Support cudd4-rc

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -9,7 +9,7 @@ def copy_file(data_dir, file_name):
     shutil.copy(os.path.join(data_dir, file_name), '.')
 
 p = argparse.ArgumentParser()
-p.add_argument('--cudnn', choices=['none', 'cudnn2', 'cudnn3'], required=True)
+p.add_argument('--cudnn', choices=['none', 'cudnn2', 'cudnn3', 'cudnn4-rc'], required=True)
 p.add_argument('-d', '--datadir', default='/opt/cuda')
 args = p.parse_args()
 
@@ -17,3 +17,5 @@ if args.cudnn == 'cudnn2':
     copy_file(args.datadir, 'cudnn-6.5-linux-x64-v2.tgz')
 elif args.cudnn == 'cudnn3':
     copy_file(args.datadir, 'cudnn-7.0-linux-x64-v3.0-prod.tgz')
+elif args.cudnn == 'cudnn4-rc':
+    copy_file(args.datadir, 'cudnn-7.0-linux-x64-v4.0-rc.tgz')


### PR DESCRIPTION
We need to support cudnn4-rc in prepare.py script to test cudnn v4-rc.