### PR TITLE
Call random.seed to make differnt hash values

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -256,6 +256,7 @@ def build_image(name, no_cache=False):
 
 
 def make_random_name():
+    random.seed()
     return ''.join(random.choice(string.ascii_lowercase + string.digits)
                    for i in range(10))
 


### PR DESCRIPTION
To make a random identifier, we use random value. But, in `run_combination.py` script, we fixed random seed to fix order of shuffled test cases. It causes conflict of identifiers.
I added `seed()` to make identifiers random.