### PR TITLE
Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is test scripts of chainer and dockerfiles for its test environment.
 Run test scripts with options that specify the environment to test.
 
 ```
-$ ./run_multi_test.py --base=ubuntu14_py2 --numpy=numpy19 --cuda=cuda70 --cudnn=cudnn2
+$ ./run_multi_test.py --base=ubuntu14_py2 --numpy=1.9 --cuda=cuda70 --cudnn=cudnn2 --type=gpu
 ```
 
 These test scripts create `Dockerfile`, make containers, and run appropriate test scripts.


### PR DESCRIPTION
argument `--numpy`: invalid choice (choose from '1.9', '1.10', '1.11')
argument `--type` is required
