### PR TITLE
Fix docker.py to use protobuf-cpp on ubuntu16

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -250,7 +250,7 @@ RUN curl -sL -o protobuf-cpp-{protobuf}.tar.gz https://github.com/google/protobu
 RUN tar -xzf protobuf-cpp-{protobuf}.tar.gz
 RUN curl -sL -o protobuf-python-{protobuf}.tar.gz https://github.com/google/protobuf/releases/download/v{protobuf}/protobuf-python-{protobuf}.tar.gz
 RUN tar -xzf protobuf-python-{protobuf}.tar.gz
-RUN cd protobuf-{protobuf} && ./configure && make && make install && ldconfig
+RUN cd protobuf-{protobuf} && CC=/usr/bin/gcc CXX=/usr/bin/g++ ./configure && make && make install && ldconfig
 RUN cd protobuf-{protobuf}/python && python setup.py install --cpp_implementation
 '''
 


### PR DESCRIPTION
Ref: https://github.com/pfnet/chainer-test/pull/145 https://github.com/pfnet/chainer-test/pull/147