### PR TITLE
Build protobuf in parallel

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -250,7 +250,7 @@ RUN curl -sL -o protobuf-cpp-{protobuf}.tar.gz https://github.com/google/protobu
 RUN tar -xzf protobuf-cpp-{protobuf}.tar.gz
 RUN curl -sL -o protobuf-python-{protobuf}.tar.gz https://github.com/google/protobuf/releases/download/v{protobuf}/protobuf-python-{protobuf}.tar.gz
 RUN tar -xzf protobuf-python-{protobuf}.tar.gz
-RUN cd protobuf-{protobuf} && CC=/usr/bin/gcc CXX=/usr/bin/g++ ./configure && make && make install && ldconfig
+RUN cd protobuf-{protobuf} && CC=/usr/bin/gcc CXX=/usr/bin/g++ ./configure && make -j4 install && ldconfig
 RUN cd protobuf-{protobuf}/python && python setup.py install --cpp_implementation
 '''
 


### PR DESCRIPTION
4 is used to run nosetests. The magic number should be removed in near future.