### PR TITLE
Install pillow with disabling jpeg

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -9,7 +9,8 @@ cd dist
 pip install *.tar.gz --user
 cd ..
 
-python -m pip install coverage pillow --user
+python -m pip install coverage --user
+python -m pip --global-option="build_ext" --global-option="--disable-jpeg" pillow --user
 
 run="coverage run -a --branch"
 


### PR DESCRIPTION
Binary package of pillow 3.4.2 is not distributed. So this script failed to install pillow. I added build option.