### PR TITLE
Update README to require CUDA 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is test scripts of chainer and dockerfiles for its test environment.
 
 - nvidia-docker
 - Docker (>=1.7)
-- CUDA 7.5
+- CUDA 8.0
 
 ## How to use
 


### PR DESCRIPTION
Current chainer-test requires CUDA 8.0: https://github.com/pfnet/chainer-test/blob/c8936f082d9c641fcd660f2098dee5291085ec97/docker.py#L15