### PR TITLE
Fix test_example.py by installing Pillow's dependent libraries separately

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -10,6 +10,7 @@ pip install *.tar.gz --user
 cd ..
 
 python -m pip install coverage matplotlib --user
+python -m pip install olefile --user
 python -m pip install --global-option="build_ext" --global-option="--disable-jpeg" pillow --user
 
 run="coverage run -a --branch"


### PR DESCRIPTION
It seems that the latest Pillow (4.0.0) depends on [olefile](https://pypi.python.org/pypi/olefile) but olefile does not accept `--disable-jpeg`.