### PR TITLE
Build Chainer in parallel when possible

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 
 cd chainer
 flake8
-python setup.py develop install --user
+python setup.py build -j 4 develop install --user || python setup.py develop install --user
 
 if [ $CUDNN = none ]; then
   nosetests --processes=4 --process-timeout=10000 --stop --with-coverage --cover-branches --cover-package=chainer,cupy -a '!cudnn,!slow'

--- a/test_doc.sh
+++ b/test_doc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 cd chainer
-python setup.py -q develop install --user
+python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
 cd docs
 make doctest


### PR DESCRIPTION
~Old setuptools does not accept `-j` option.~ Python 2's setuptools does not accept `-j` option.