### PR TITLE
cuDNN v5.1 is updated

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -303,7 +303,7 @@ codes['cudnn51'] = cudnn_base.format(
 codes['cudnn51-cuda8'] = cudnn_base.format(
     cudnn='cudnn-8.0-linux-x64-v5.1',
     cudnn_ver='v5.1',
-    sha256sum='a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8',
+    sha256sum='c10719b36f2dd6e9ddc63e3189affaa1a94d7d027e63b71c3f64d449ab0645ce',
 )
 
 # This is a test for CFLAGS and LDFLAGS to specify a directory where cuDNN is

--- a/docker.py
+++ b/docker.py
@@ -297,7 +297,7 @@ codes['cudnn5-cuda8'] = cudnn_base.format(
 codes['cudnn51'] = cudnn_base.format(
     cudnn='cudnn-7.5-linux-x64-v5.1',
     cudnn_ver='v5.1',
-    sha256sum='40d506d0a8a00a3faccce1433346806b8cd2535683b6f08a63683ce6e474419f',
+    sha256sum='69ca71f7728b54b6e003393083f419b24774fecd3b08bbf41bceac9a9fe16345',
 )
 
 codes['cudnn51-cuda8'] = cudnn_base.format(


### PR DESCRIPTION
cuDNN v5.1 for CUDA 7.5 is updated and its sha256sum is changed.