### PR TITLE
Stop using NCCL with CentOS 6

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -44,7 +44,7 @@ def get_shuffle_params(params, index):
     if ret['numpy'] == '1.9' and ret['h5py'] != 'none':
         ret['numpy'] = '1.10'
 
-    if ret['cuda'] in ('none', 'cuda65'):
+    if 'centos6' in ret['base'] or ret['cuda'] in ('none', 'cuda65'):
         ret['nccl'] = 'none'
 
     return ret

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -37,8 +37,8 @@ def get_shuffle_params(params, index):
     vals = next(itertools.islice(six.moves.zip(*iters), index, None))
     ret = dict(zip(keys, vals))
 
-    # Avoid this combination because NCCL is not supported on CUDA6.5
-    if ret['cuda'] in ('none', 'cuda65'):
+    # Avoid this combination because NCCL is not supported or cannot built
+    if 'centos6' in ret['base'] or ret['cuda'] in ('none', 'cuda65'):
         ret['nccl'] = 'none'
 
     return ret


### PR DESCRIPTION
Stop using NCCL with CentOS 6 because GCC 4.4 does not support `-std=c++11` option.