### PR TITLE
Ignore NCCL on Ubuntu 16.04 with CUDA<8.0

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -43,7 +43,7 @@ def get_shuffle_params(params, index):
     if ret['numpy'] == '1.9' and ret['h5py'] != 'none':
         ret['numpy'] = '1.10'
 
-    if 'centos6' in ret['base'] or ret['cuda'] == 'none':
+    if 'centos6' in ret['base'] or ret['cuda'] == 'none' or ('ubuntu16' in ret['base'] and ret['cuda'] != 'cuda80'):
         ret['nccl'] = 'none'
 
     return ret

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -37,7 +37,7 @@ def get_shuffle_params(params, index):
     ret = dict(zip(keys, vals))
 
     # Avoid this combination because NCCL is not supported or cannot built
-    if 'centos6' in ret['base'] or ret['cuda'] == 'none':
+    if 'centos6' in ret['base'] or ret['cuda'] == 'none' or ('ubuntu16' in ret['base'] and ret['cuda'] != 'cuda80'):
         ret['nccl'] = 'none'
 
     return ret


### PR DESCRIPTION
Fix the problem of https://github.com/cupy/cupy/pull/70 for NCCL.